### PR TITLE
Use DynamoDB as semaphore to ensure idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,19 @@ Run a job on ECS using CloudWatch Events -> Lambda
 
 ### Required IAM Policy for function
 
-`ecs:RunTask` must be authorized.
+`dynamodb:UpdateItem` for Lock manager table and `ecs:RunTask` must be authorized.
 
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
+    {
+      "Action": [
+        "dynamodb:UpdateItem"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:dynamodb:ap-northeast-1:123456789012:table/SchedulerLockManager"
+    },
     {
       "Action": [
         "ecs:RunTask"
@@ -22,6 +29,20 @@ Run a job on ECS using CloudWatch Events -> Lambda
   ]
 }
 ```
+
+### Required DynamoDB table
+
+#### Lock manager (e,g. `SchedulerLockManager`)
+
+|key|type|
+|---|---|
+|ARN|string|
+
+### Function environment variables
+
+|key|description|required|
+|---|---|---|
+|`DYNAMODB_TABLENAME`|DynamoDB table name for lock manager|`SchedulerLockManager`|
 
 ### Input event JSON
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Run a job on ECS using CloudWatch Events -> Lambda
 
 |key|value|
 |---|---|
+|`arn`|CloudWatch Events Rule ARN|
+|`timestamp`|Timestamp when the event invoked|
 |`cluster`|ECS cluster name|
 |`command`|Command to execute as job (= `CMD` in `Dockerfile`)|
 |`container`|Container name to use|

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Run a job on ECS using CloudWatch Events -> Lambda
 
 |key|description|required|
 |---|---|---|
-|`DYNAMODB_TABLENAME`|DynamoDB table name for lock manager|`SchedulerLockManager`|
+|`DYNAMODB_TABLENAME`|DynamoDB table name for lock manager|required|
 
 ### Input event JSON
 

--- a/event.json.sample
+++ b/event.json.sample
@@ -1,4 +1,6 @@
 {
+  "arn": "your ARN name",
+  "timestamp": "2017-03-13T07:23:22Z",
   "cluster": "sample-cluster",
   "command": ["ruby", "-v"],
   "container": "job",

--- a/index.js
+++ b/index.js
@@ -92,6 +92,10 @@ exports.handler = (event, context, callback) => {
   }).then(_ => {
     callback(null, "SUCCESS");
   }).catch(err => {
-    callback(err);
+    if (err.code == 'ConditionalCheckFailedException') {
+      callback('duplicated execution: ' + JSON.stringify(event));
+    } else {
+      callback(err);
+    }
   });
 };

--- a/index.js
+++ b/index.js
@@ -11,6 +11,13 @@ let AWS = require('aws-sdk');
 let dynamodb = new AWS.DynamoDB();
 let ecs = new AWS.ECS();
 
+function toUnixTimestampWithoutSeconds(timestamp) {
+  let d = new Date(timestamp);
+  d.setSeconds(0);
+
+  return d.getTime().toString();
+}
+
 function validateEvent(event) {
   let missingKeys = [];
 
@@ -62,7 +69,7 @@ exports.handler = (event, context, callback) => {
 
   let tableName = process.env.DYNAMODB_TABLENAME;
   let arn = event['arn'];
-  let timestamp = event['timestamp'];
+  let timestamp = toUnixTimestampWithoutSeconds(event['timestamp']);
 
   let missingKeys = validateEvent(event);
 


### PR DESCRIPTION
Close #1 

## WHY 

Sometimes lambda function invokes twice or more from ONE invocation operation.

## WHAT

Check whether the given invocation was processed already or not.
To do this, use DynamoDB as semaphore.

DynamoDB conditional writes ensure idempotency:
http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithItems.html#WorkingWithItems.ConditionalUpdate